### PR TITLE
Fix PRECONDITION_FAILED errors on exchange declaration

### DIFF
--- a/asgi_rabbitmq/core.py
+++ b/asgi_rabbitmq/core.py
@@ -379,6 +379,7 @@ class Protocol(object):
             declare_queue,
             exchange=self.dead_letters,
             exchange_type='fanout',
+            auto_delete=True,
         )
 
     def on_dead_letter(self, amqp_channel, method_frame, properties, body):

--- a/asgi_rabbitmq/core.py
+++ b/asgi_rabbitmq/core.py
@@ -379,7 +379,6 @@ class Protocol(object):
             declare_queue,
             exchange=self.dead_letters,
             exchange_type='fanout',
-            auto_delete=True,
         )
 
     def on_dead_letter(self, amqp_channel, method_frame, properties, body):


### PR DESCRIPTION
Hi Artem,
Thanks for 0.5.2! It really helped to keep Rabbitmq queues list clean!
This is just a little fix for errors that appear every time on user connection/message receive:
```
ChannelClosed: (406, "PRECONDITION_FAILED - inequivalent arg 'auto_delete' for exchange 'users-1415' in vhost '/'': received 'false' but current is 'true'")
```